### PR TITLE
Separate TextShouts from other kinds of content

### DIFF
--- a/app/controllers/shouts_controller.rb
+++ b/app/controllers/shouts_controller.rb
@@ -11,6 +11,14 @@ class ShoutsController < ApplicationController
   private
 
   def shout_params
+    { content: content_from_params }
+  end
+
+  def content_from_params
+    TextShout.new(content_params)
+  end
+
+  def content_params
     params.require(:shout).permit(:body)
   end
 

--- a/app/models/shout.rb
+++ b/app/models/shout.rb
@@ -1,7 +1,7 @@
 class Shout < ApplicationRecord
   belongs_to :user
+  belongs_to :content, polymorphic: true
 
-  validates :body, presence: true, length: { in: 1..144 }
   validates :user, presence: true
 
   delegate :username, to: :user

--- a/app/models/text_shout.rb
+++ b/app/models/text_shout.rb
@@ -1,0 +1,3 @@
+class TextShout < ApplicationRecord
+  validates :body, presence: true, length: { in: 1..144 }
+end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -3,7 +3,9 @@
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Ye7FKc1JQe4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <%= form_for @shout do |form| %>
-    <%= form.text_field :body, placeholder: "Shout here!", required: true %>
+    <%= form.fields_for :content do |content_form| %>
+        <%= content_form.text_field :body, placeholder: "Shout here!", required: true %>
+    <% end %>
     <%= form.submit "Shout!" %>
 <% end %>
 

--- a/app/views/shouts/_shout.html.erb
+++ b/app/views/shouts/_shout.html.erb
@@ -1,7 +1,7 @@
 <div>
     <%= link_to shout.username, shout.user %>
     <%= shout.id %>
-    <%= shout.body %>
+    <%= shout.content.body %>
     <%= link_to shout do %>
         <%= time_ago_in_words shout.created_at %> ago
     <% end %>

--- a/db/migrate/20190306021958_create_text_shouts.rb
+++ b/db/migrate/20190306021958_create_text_shouts.rb
@@ -1,0 +1,9 @@
+class CreateTextShouts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :text_shouts do |t|
+      t.string :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190306022123_make_shouts_polymorphic.rb
+++ b/db/migrate/20190306022123_make_shouts_polymorphic.rb
@@ -1,0 +1,36 @@
+class MakeShoutsPolymorphic < ActiveRecord::Migration[5.2]
+  # Declare the involved models here so we don't have any validation
+  # problems in the future.
+  class Shout < ApplicationRecord
+    belongs_to :content, polymorphic: true
+  end
+  class TextShout < ApplicationRecord; end
+
+  def change
+    change_table(:shouts) do |t|
+      t.string :content_type
+      t.integer :content_id
+      t.index [:content_type, :content_id]
+    end
+
+
+    # With this we can reverse this migration, depending on direction
+    reversible do |direction|
+      Shout.reset_column_information
+      Shout.find_each do |shout|
+        # Copy the old Shouts to TextShouts.
+        direction.up do
+          text_shout = TextShout.create(body: shout.body)
+          shout.update(content_id: text_shout.id, content_type: "TextShout")
+        end
+
+        direction.down do
+          shout.update(body: shout.content.body)
+          shout.content.destroy
+        end
+      end
+    end
+
+    remove_column :shouts, :body, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_05_161052) do
+ActiveRecord::Schema.define(version: 2019_03_06_022123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "shouts", force: :cascade do |t|
-    t.string "body", null: false
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "content_type"
+    t.integer "content_id"
+    t.index ["content_type", "content_id"], name: "index_shouts_on_content_type_and_content_id"
     t.index ["user_id"], name: "index_shouts_on_user_id"
+  end
+
+  create_table "text_shouts", force: :cascade do |t|
+    t.string "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
This PR copies the old Shouts to new TextShout models, since they're text-based only, and prepares the app to receive Shouts with other kinds of data associated to them, such as images and (maybe in the future) audio.